### PR TITLE
Expose docker port to probe healthz and ready [ch885]

### DIFF
--- a/dev/run-image.sh
+++ b/dev/run-image.sh
@@ -2,4 +2,5 @@
 
 docker stop model-dev
 docker rm model-dev
-docker run -d --network=mdai-dev --name=model-dev model-dev:latest
+docker run -d --network=mdai-dev --name=model-dev -p 6324:6324 model-dev:latest
+echo "Server listening on localhost port 6324"


### PR DESCRIPTION
Exposes port on localhost so that devs can probe /healthz and /ready routes from localhost:6324.