### PR TITLE
Send dicom files directly to inference [ch932]

### DIFF
--- a/dev/inference.py
+++ b/dev/inference.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+from preprocess import ProcessData
+import sys
+import requests
+import os
+import json
+import msgpack
+
+INFERENCE_ENDPOINT = 'http://localhost:6324/inference'
+
+
+def MakeInference(path):
+    payload = ProcessData(path)
+    headers = {"content-type": "application/msgpack"}
+    r = requests.post(INFERENCE_ENDPOINT, data=payload, headers=headers)
+    if r.status_code == 200:
+        return msgpack.unpackb(r.content)
+    else:
+        print('Error: status code {} when contacting endpoint'.format(r.status_code), file=sys.stderr)
+        return None
+
+
+if __name__ == "__main__":
+    if(len(sys.argv) < 2):
+        print('Error: Argument required for data', file=sys.stderr)
+    else:
+        path = sys.argv[1]
+        if(not os.path.exists(path)):
+            print('Error: Path for data does not exist', file=sys.stderr)
+        else:
+            data = MakeInference(path)
+            if(data is not None):
+                json_data = json.dumps(data)
+                print(json_data, file=sys.stdout, flush=True)

--- a/dev/inference.py
+++ b/dev/inference.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
 
-from .preprocess import process_data
+from preprocess import process_data
 import sys
 import requests
 import os
 import json
 import msgpack
+from argparse import ArgumentParser
 
 INFERENCE_ENDPOINT = "http://localhost:6324/inference"
+INDENT_SPACES = 4
 
 
 def make_inference(path):
@@ -23,15 +25,37 @@ def make_inference(path):
         return None
 
 
+def parse_arguments():
+    parser = ArgumentParser(description="Send Dicom files to /inference")
+    parser.add_argument("path", type=str, help="Path to DICOM file(s)")
+    parser.add_argument("--raw", action="store_true", help="output raw output data")
+    parser.add_argument("--pretty", action="store_true", help="prettify json output")
+    args = parser.parse_args()
+    path = args.path
+    output_raw = args.raw
+    output_pretty = args.pretty
+    return path, output_raw, output_pretty
+
+
+def output_json(data):
+    if data is not None:
+        indent = None
+
+        if not output_raw:
+            for instance in data:
+                instance.pop("data", None)
+                instance.pop("explanations", None)
+
+        if output_pretty:
+            indent = INDENT_SPACES
+        json_data = json.dumps(data, indent=indent)
+        print(json_data, file=sys.stdout, flush=True)
+
+
 if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        print("Error: Argument required for data", file=sys.stderr)
+    path, output_raw, output_pretty = parse_arguments()
+    if not os.path.exists(path):
+        print("Error: Path for data does not exist", file=sys.stderr)
     else:
-        path = sys.argv[1]
-        if not os.path.exists(path):
-            print("Error: Path for data does not exist", file=sys.stderr)
-        else:
-            data = make_inference(path)
-            if data is not None:
-                json_data = json.dumps(data)
-                print(json_data, file=sys.stdout, flush=True)
+        data = make_inference(path)
+        output_json(data)

--- a/dev/inference.py
+++ b/dev/inference.py
@@ -1,35 +1,37 @@
 #!/usr/bin/env python3
 
-from preprocess import ProcessData
+from .preprocess import process_data
 import sys
 import requests
 import os
 import json
 import msgpack
 
-INFERENCE_ENDPOINT = 'http://localhost:6324/inference'
+INFERENCE_ENDPOINT = "http://localhost:6324/inference"
 
 
-def MakeInference(path):
-    payload = ProcessData(path)
+def make_inference(path):
+    payload = process_data(path)
     headers = {"content-type": "application/msgpack"}
     r = requests.post(INFERENCE_ENDPOINT, data=payload, headers=headers)
     if r.status_code == 200:
         return msgpack.unpackb(r.content)
     else:
-        print('Error: status code {} when contacting endpoint'.format(r.status_code), file=sys.stderr)
+        print(
+            "Error: status code {} when contacting endpoint".format(r.status_code), file=sys.stderr
+        )
         return None
 
 
 if __name__ == "__main__":
-    if(len(sys.argv) < 2):
-        print('Error: Argument required for data', file=sys.stderr)
+    if len(sys.argv) < 2:
+        print("Error: Argument required for data", file=sys.stderr)
     else:
         path = sys.argv[1]
-        if(not os.path.exists(path)):
-            print('Error: Path for data does not exist', file=sys.stderr)
+        if not os.path.exists(path):
+            print("Error: Path for data does not exist", file=sys.stderr)
         else:
-            data = MakeInference(path)
-            if(data is not None):
+            data = make_inference(path)
+            if data is not None:
                 json_data = json.dumps(data)
                 print(json_data, file=sys.stdout, flush=True)

--- a/dev/preprocess.py
+++ b/dev/preprocess.py
@@ -4,52 +4,52 @@ import pydicom
 from io import BytesIO
 import msgpack
 
-PATH_DELIMITER = '/'
-DCM_EXTENSION = '.dcm'
+PATH_DELIMITER = "/"
+DCM_EXTENSION = ".dcm"
 
 
-def IsFolder(path):
+def is_folder(path):
     return os.path.isdir(path)
 
 
-def IsDicom(path):
+def is_dicom(path):
     return path.endswith(DCM_EXTENSION)
 
 
-def FileSearch(path):
-    if(not IsFolder(path)):
-        if(IsDicom(path)):
-            return[path]
+def file_search(path):
+    if not is_folder(path):
+        if is_dicom(path):
+            return [path]
         else:
             return []
 
     file_paths = []
     folder_queue = [path]
-    while(len(folder_queue) != 0):
+    while len(folder_queue) != 0:
         current_folder = folder_queue.pop(0)
 
         for path in listdir(current_folder):
             current_path = current_folder + PATH_DELIMITER + path
-            if(IsFolder(current_path)):
+            if is_folder(current_path):
                 folder_queue.append(current_path)
-            elif(IsDicom(current_path)):
+            elif is_dicom(current_path):
                 file_paths.append(current_path)
 
     return file_paths
 
 
-def ProcessData(path):
-    file_paths = FileSearch(path)
+def process_data(path):
+    file_paths = file_search(path)
     result = {}
     result["instances"] = []
     result["args"] = {}
     for path in file_paths:
-        result["instances"].append(ProcessFile(path))
+        result["instances"].append(process_file(path))
     return msgpack.packb(result)
 
 
-def ProcessFile(path):
-    with open(path, 'rb') as fp:
+def process_file(path):
+    with open(path, "rb") as fp:
         instance = {}
         file_content = fp.read()
         dicom_content = pydicom.read_file(BytesIO(file_content))

--- a/dev/preprocess.py
+++ b/dev/preprocess.py
@@ -1,0 +1,64 @@
+import os
+from os import listdir
+import pydicom
+from io import BytesIO
+import msgpack
+
+PATH_DELIMITER = '/'
+DCM_EXTENSION = '.dcm'
+
+
+def IsFolder(path):
+    return os.path.isdir(path)
+
+
+def IsDicom(path):
+    return path.endswith(DCM_EXTENSION)
+
+
+def FileSearch(path):
+    if(not IsFolder(path)):
+        if(IsDicom(path)):
+            return[path]
+        else:
+            return []
+
+    file_paths = []
+    folder_queue = [path]
+    while(len(folder_queue) != 0):
+        current_folder = folder_queue.pop(0)
+
+        for path in listdir(current_folder):
+            current_path = current_folder + PATH_DELIMITER + path
+            if(IsFolder(current_path)):
+                folder_queue.append(current_path)
+            elif(IsDicom(current_path)):
+                file_paths.append(current_path)
+
+    return file_paths
+
+
+def ProcessData(path):
+    file_paths = FileSearch(path)
+    result = {}
+    result["instances"] = []
+    result["args"] = {}
+    for path in file_paths:
+        result["instances"].append(ProcessFile(path))
+    return msgpack.packb(result)
+
+
+def ProcessFile(path):
+    with open(path, 'rb') as fp:
+        instance = {}
+        file_content = fp.read()
+        dicom_content = pydicom.read_file(BytesIO(file_content))
+
+        tags = {}
+        tags["StudyInstanceUID"] = dicom_content.StudyInstanceUID
+        tags["SeriesInstanceUID"] = dicom_content.SeriesInstanceUID
+        tags["SOPInstanceUID"] = dicom_content.SOPInstanceUID
+        instance["tags"] = tags
+        instance["file"] = file_content
+
+        return instance

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 flake8
 black
 docker
+msgpack
+json
+pydicom
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ flake8
 black
 docker
 msgpack
-json
 pydicom
 requests


### PR DESCRIPTION
This commits allows us to send dicom file/folders directly to /inference without using the UI. We get back the data in json format on STDOUT. 

Usage: ./inference.py <path to dicom file/folders>