### PR TITLE
Model deployment config file [ch1099]

### DIFF
--- a/examples/lung-segmentation/config.yaml
+++ b/examples/lung-segmentation/config.yaml
@@ -1,0 +1,4 @@
+base_image: py37
+paths:
+    mdai_folder: .
+    model_folder: .

--- a/examples/xray-classification/config.yaml
+++ b/examples/xray-classification/config.yaml
@@ -1,0 +1,4 @@
+base_image: py37
+paths:
+    mdai_folder: .
+    model_folder: .

--- a/mdai/config.yaml
+++ b/mdai/config.yaml
@@ -1,0 +1,6 @@
+base_image: <string> # path to Dockerfile of base image
+paths:
+    mdai_folder: <string> # path to mdai related files inside target folder
+    model_folder: <string> # path to root folder of model
+env: <string: value> # some key-val pairs which can be passed to the server at runtime
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ msgpack
 pydicom
 pytest
 requests
+pyyaml

--- a/scripts/build-image.py
+++ b/scripts/build-image.py
@@ -4,15 +4,21 @@ import os
 from argparse import ArgumentParser
 from shutil import copyfile, copytree, rmtree
 import docker
+import yaml
 
 BASE_DIRECTORY = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
 
 def parse_arguments():
     parser = ArgumentParser(description="Build docker image for model deployment")
-    parser.add_argument("--docker_env", type=str, help="Docker environment to use", required=True)
     parser.add_argument("--image_name", type=str, help="Name of docker output image", required=True)
-    parser.add_argument("--target_folder", type=str, help="path of model folder", required=True)
+    parser.add_argument("--docker_env", type=str, help="Docker environment to use", default="py37")
+    parser.add_argument(
+        "--mdai_folder", type=str, help="path of mdai deployment folder", default=None
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--target_folder", type=str, help="path of model folder", default=None)
+    group.add_argument("--config_file", type=str, help="path to yaml config file", default=None)
     args = parser.parse_args()
     return args
 
@@ -22,9 +28,30 @@ if __name__ == "__main__":
     cwd = os.getcwd()
 
     args = parse_arguments()
-    docker_env = args.docker_env
+    config_file = args.config_file
+
+    if config_file is not None:
+        config_file = os.path.abspath(config_file)
+        parent_dir = os.path.dirname(config_file)
+        os.chdir(parent_dir)
+
+        with open(config_file, "r") as stream:
+            data = yaml.safe_load(stream)
+            docker_env = data["base_image"]
+            target_folder = os.path.abspath(data["paths"]["model_folder"])
+            mdai_folder = os.path.abspath(data["paths"]["mdai_folder"])
+
+        os.chdir(cwd)
+    else:
+        docker_env = args.docker_env
+        target_folder = os.path.abspath(args.target_folder)
+
+        if args.mdai_folder is None:  # If None, defaults to root of target folder
+            mdai_folder = target_folder
+        else:
+            mdai_folder = os.path.abspath(args.mdai_folder)
+
     docker_image = args.image_name
-    target_folder = os.path.abspath(args.target_folder)
 
     os.chdir(os.path.join(BASE_DIRECTORY, "mdai"))
 


### PR DESCRIPTION
Allows users to pass a config file to configure the build process. The user is required to either give the target folder or a config file. Currently the mdai folder for each config defaults to the root of the folder.