### PR TITLE
Affanmd/ch1318/create base gpu docker env for model deploy

### DIFF
--- a/dev/build-image.py
+++ b/dev/build-image.py
@@ -107,7 +107,7 @@ if __name__ == "__main__":
 
         placeholder_values = hot_reload_values
 
-        helper.resolve_parent_image(hot, config, helper.PARENT_IMAGE_DICT)
+        helper.resolve_parent_image(placeholder_values, config, helper.PARENT_IMAGE_DICT)
         helper.add_env_variables(placeholder_values, config.get("env"))
         relative_mdai_folder = os.path.relpath(mdai_folder, target_folder)
         os.chdir(os.path.join(BASE_DIRECTORY, "mdai"))

--- a/dev/build-image.py
+++ b/dev/build-image.py
@@ -14,13 +14,16 @@ HELPER_DIR = os.path.join(BASE_DIRECTORY, "scripts")
 sys.path.insert(0, HELPER_DIR)
 
 hot_reload_values = {
+    "{{PARENT_IMAGE}}": [],
     "{{COPY}}": [
         "COPY main.sh /src/",
         'RUN ["chmod", "+x", "/src/main.sh"]',
         "RUN apt-get update",
         "RUN apt-get install -y inotify-tools",
     ],
-    "{{COMMAND}}": ['CMD ["sh", "-c", "./main.sh /src/lib /src/lib/$MDAI_PATH"]'],
+    "{{COMMAND}}": [
+        'CMD ["/bin/bash", "-c", "source activate mdai-env ; ./main.sh /src/lib /src/lib/$MDAI_PATH"]'
+    ],
     "{{ENV}}": [],
 }
 
@@ -57,14 +60,23 @@ def copy_files(target_folder, docker_env, placeholder_values):
     return [os.path.abspath(file_copy) for file_copy in copies]
 
 
-def write_info_file(target_folder):
-    target_folder = os.path.abspath(target_folder)
+def write_info_file(args):
+    target_folder = os.path.abspath(args.target_folder)
     with open(INFO_FILE, "w") as f:
         info = {"model_path": target_folder}
         if hot_reload:
             info["dev"] = True
         else:
             info["dev"] = False
+
+        _, _, config_file = helper.get_paths(args)
+        config = helper.process_config_file(config_file)
+
+        if config.get("device_type") == "gpu":
+            info["device_type"] = "gpu"
+        else:
+            info["device_type"] = "cpu"
+
         f.write(json.dumps(info))
 
 
@@ -73,7 +85,7 @@ if __name__ == "__main__":
 
     args = parse_arguments()
     hot_reload = args.hot_reload
-    write_info_file(args.target_folder)
+    write_info_file(args)
 
     if hot_reload:
         client = docker.from_env()
@@ -91,18 +103,19 @@ if __name__ == "__main__":
 
         # Prioritize config file values if it exists
         if config_file is not None:
-            docker_env, env = helper.process_config_file(config_file)
+            config = helper.process_config_file(config_file)
 
         placeholder_values = hot_reload_values
 
-        helper.add_env_variables(placeholder_values, env)
+        helper.resolve_parent_image(hot, config, helper.PARENT_IMAGE_DICT)
+        helper.add_env_variables(placeholder_values, config.get("env"))
         relative_mdai_folder = os.path.relpath(mdai_folder, target_folder)
         os.chdir(os.path.join(BASE_DIRECTORY, "mdai"))
-        copies = copy_files(target_folder, docker_env, placeholder_values)
+        copies = copy_files(target_folder, config["base_image"], placeholder_values)
 
         try:
             helper.build_image(client, docker_image, relative_mdai_folder)
-        except docker.errors as e:
+        except Exception as e:
             print("\nBuild Error: {}".format(e))
         finally:
             helper.remove_files(copies)

--- a/dev/build-image.py
+++ b/dev/build-image.py
@@ -115,7 +115,7 @@ if __name__ == "__main__":
 
         try:
             helper.build_image(client, docker_image, relative_mdai_folder)
-        except Exception as e:
+        except docker.errors as e:
             print("\nBuild Error: {}".format(e))
         finally:
             helper.remove_files(copies)

--- a/dev/run-image.py
+++ b/dev/run-image.py
@@ -19,6 +19,10 @@ if __name__ == "__main__":
         with open(INFO_FILE, "r") as f:
             model_info = json.loads(f.read())
 
+    runtime = None
+    if model_info["device_type"] == "gpu":
+        runtime = "nvidia"
+
     if model_info["dev"] is True:
         client.containers.run(
             "model-dev:latest",
@@ -27,6 +31,7 @@ if __name__ == "__main__":
             ports={"6324/tcp": 6324},
             volumes={model_info["model_path"]: {"bind": "/src/lib", "mode": "rw"}},
             detach=True,
+            runtime=runtime,
         )
     else:
         client.containers.run(
@@ -35,5 +40,6 @@ if __name__ == "__main__":
             network="mdai-dev",
             ports={"6324/tcp": 6324},
             detach=True,
+            runtime=runtime,
         )
     print("Server listening on localhost port 6324")

--- a/docker/py37/Dockerfile.template
+++ b/docker/py37/Dockerfile.template
@@ -1,15 +1,16 @@
-FROM python:3.7.6
+{{PARENT_IMAGE}}
 
 WORKDIR /src
 ARG MDAI_PATH
 
 {{ENV}}
 
+RUN conda create -n mdai-env python=3.7 pip
 COPY requirements.txt /src/requirements.txt
-RUN pip install -r requirements.txt
-
 COPY lib/${MDAI_PATH}/requirements.txt /src/mdai-requirements.txt
-RUN pip install -r mdai-requirements.txt
+RUN /bin/bash -c "source activate mdai-env && \
+    pip install -r requirements.txt && \
+    pip install -r mdai-requirements.txt"
 
 COPY server.py /src/
 COPY validation.py /src/

--- a/examples/lung-segmentation/.mdai/config.yaml
+++ b/examples/lung-segmentation/.mdai/config.yaml
@@ -1,1 +1,3 @@
 base_image: py37
+device_type: gpu
+framework: tensorflow_2

--- a/examples/lung-segmentation/.mdai/config.yaml
+++ b/examples/lung-segmentation/.mdai/config.yaml
@@ -1,3 +1,2 @@
 base_image: py37
 device_type: gpu
-framework: tensorflow_2

--- a/examples/xray-classification/.mdai/config.yaml
+++ b/examples/xray-classification/.mdai/config.yaml
@@ -1,1 +1,3 @@
 base_image: py37
+device_type: gpu
+framework: tensorflow_2

--- a/examples/xray-classification/.mdai/config.yaml
+++ b/examples/xray-classification/.mdai/config.yaml
@@ -1,3 +1,2 @@
 base_image: py37
 device_type: gpu
-framework: tensorflow_2

--- a/mdai/config.yaml
+++ b/mdai/config.yaml
@@ -1,3 +1,4 @@
-base_image: <string> # path to Dockerfile of base image
+base_image: <string> # base docker image. Currently only py37 is supported
+device_type: <string> # Can be one of two values (cpu/gpu) to indicate build type. Default is cpu
+framework: <string> # if device_type=gpu, deep learning framework needs to be specified. Supported values are tensorflow_1, tensorflow_2, pytorch
 env: <string: value> # some key-val pairs which can be passed to the server at runtime
-

--- a/mdai/config.yaml
+++ b/mdai/config.yaml
@@ -1,4 +1,3 @@
 base_image: <string> # base docker image. Currently only py37 is supported
 device_type: <string> # Can be one of two values (cpu/gpu) to indicate build type. Default is cpu
-framework: <string> # if device_type=gpu, deep learning framework needs to be specified. Supported values are tensorflow_1, tensorflow_2, pytorch
 env: <string: value> # some key-val pairs which can be passed to the server at runtime

--- a/scripts/helper.py
+++ b/scripts/helper.py
@@ -17,9 +17,7 @@ PLACEHOLDER_VALUES = {
 
 PARENT_IMAGE_DICT = {
     "cpu": "gcr.io/deeplearning-platform-release/base-cpu",
-    "tensorflow_1": "gcr.io/deeplearning-platform-release/tf-gpu.1-15",
-    "tensorflow_2": "gcr.io/deeplearning-platform-release/tf2-gpu.2-1",
-    "pytorch": "gcr.io/deeplearning-platform-release/pytorch-gpu.1-4",
+    "gpu": "gcr.io/deeplearning-platform-release/base-cu101",
 }
 
 
@@ -114,18 +112,7 @@ def resolve_parent_image(placeholder_dict, config, image_dict):
     if device_type == "cpu":
         parent_image = image_dict.get("cpu")
     elif device_type == "gpu":
-        framework = config.get("framework")
-
-        if framework is None:
-            print("missing required arugument: framework", file=sys.stderr)
-            sys.exit()
-
-        framework = framework.lower()
-        parent_image = image_dict.get(framework)
-
-        if parent_image is None:
-            print("invalid value for arguemnt: framework", file=sys.stderr)
-            sys.exit()
+        parent_image = image_dict.get("gpu")
     else:
         print("invalid device type", file=sys.stderr)
         sys.exit()


### PR DESCRIPTION
Updates Docker template to allow gpus to be used. 

A conda environment is created to install required packages by the user and everything is run within the environment.

In order to run gpu images, the user needs to install Nvidia-docker2. 