### PR TITLE
Update file watcher to watch the root model [ch1343]

### DIFF
--- a/dev/build-image.py
+++ b/dev/build-image.py
@@ -18,12 +18,9 @@ hot_reload_values = {
     "{{COPY}}": [
         "COPY main.sh /src/",
         'RUN ["chmod", "+x", "/src/main.sh"]',
-        "RUN apt-get update",
-        "RUN apt-get install -y inotify-tools",
+        'RUN /bin/bash -c "source activate mdai-env && pip install watchdog argh pyyaml"',
     ],
-    "{{COMMAND}}": [
-        'CMD ["/bin/bash", "-c", "source activate mdai-env ; ./main.sh /src/lib /src/lib/$MDAI_PATH"]'
-    ],
+    "{{COMMAND}}": ['CMD ["/bin/bash", "-c", "source activate mdai-env ; ./main.sh /src/lib"]'],
     "{{ENV}}": [],
 }
 

--- a/dev/main.sh
+++ b/dev/main.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 
 MODEL_DIRECTORY=$1
-MDAI_DIRECTORY=$2
 
-while true; do
-  python server.py &
-  PID=$!
-  inotifywait -e modify  $MODEL_DIRECTORY/* $MDAI_DIRECTORY/*
-  kill $PID
-done
+watchmedo auto-restart -d $MODEL_DIRECTORY -D -R --signal SIGKILL python server.py


### PR DESCRIPTION
This PR makes 2 primary changes. 

1. watches the root directory recursively instead of just the mdai directory so that any file changes trigger a server restart

2. switches from notify-tools to watchdog for watching files