### PR TITLE
Update return type for testing-on-batch endpoint [ch3134]

### DIFF
--- a/examples/xray-classification/model/.mdai/mdai_deploy.py
+++ b/examples/xray-classification/model/.mdai/mdai_deploy.py
@@ -87,13 +87,16 @@ class MDAIModel:
         input_files = data["files"]
         input_targets = data["targets"]
 
-        outputs = [
-            {
-                "name": "Accuracy",
-                "values": [],
-                "reduction": "mean",
-            }
-        ]
+        outputs = {
+            "metrics": [
+                {
+                    "name": "Accuracy",
+                    "values": [],
+                    "reduction": "mean",
+                }
+            ],
+            "errors": [],
+        }
 
         for i, file in enumerate(input_files):
             if file["content_type"] != "application/dicom":
@@ -115,8 +118,16 @@ class MDAIModel:
                 if item["resource_scope"] == "INSTANCE"
                 and item["resource_uid"] == ds.SOPInstanceUID
             )
+
             if target["target_type"] != "NONE":
-                outputs[0]["values"].append(
+                outputs["metrics"][0]["values"].append(
                     1 if int(class_index) == int(target["target_class_index"]) else 0
+                )
+            else:
+                outputs["errors"].append(
+                    {
+                        "resource_uid": str(ds.SOPInstanceUID),
+                        "error_message": "Missing annotation for resource",
+                    }
                 )
         return outputs

--- a/mdai/server.py
+++ b/mdai/server.py
@@ -183,14 +183,23 @@ async def testing_on_batch(request: Request):
 
     The response body should be the msgpack-serialized binary data of the results:
 
-    [
-        {
-            "name": "str", # For example, 'Mean Squared Error'
-            "values": "float[]",
-            "reduction": "str", # 'mean' or 'sum'
-        },
-        ...
-    ]
+    {
+        metrics: [
+            {
+                "name": "str", # For example, 'Mean Square Error'
+                "values": "float[]",
+                "reduction": "str", # 'mean' or 'sum'
+            },
+            ...
+        ],
+        errors: [
+            {
+                "resource_uid": "str", # uid for 'STUDY', 'SERIES', or 'INSTANCE',
+                "error_message": "str", # For example, 'Missing annotation for the resource'
+            },
+            ...
+        ]
+    }
     """
 
     loop = asyncio.get_event_loop()


### PR DESCRIPTION
Adds support for returning error messages during metric testing in case annotations are missing for a given scope.